### PR TITLE
Improve translation accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # MidjourneyCN
+
+Chrome 扩展用于将 MidJourney 官网界面翻译为中文。词典会自动缓存 6 小时并支持简/繁体切换。


### PR DESCRIPTION
## Summary
- update README with basic usage notes
- better text normalization and case handling
- translate value attributes and skip script-like nodes
- observe additional attributes

## Testing
- `node --check content.js`

------
https://chatgpt.com/codex/tasks/task_e_686e74a4a6b0832abd171803a87a88f0